### PR TITLE
Add support for view relation options

### DIFF
--- a/results/schemainspect/inspected.py
+++ b/results/schemainspect/inspected.py
@@ -278,6 +278,7 @@ class InspectedSelectable(Inspected):
     def __init__(
         self,
         name,
+        rel_options,
         schema,
         columns,
         inputs=None,
@@ -294,6 +295,7 @@ class InspectedSelectable(Inspected):
         oid=None,
     ):
         self.name = name
+        self.rel_options = rel_options
         self.schema = schema
         self.inputs = inputs or []
         self.columns = columns

--- a/results/schemainspect/inspected.py
+++ b/results/schemainspect/inspected.py
@@ -328,5 +328,6 @@ class InspectedSelectable(Inspected):
             self.partition_def == other.partition_def,
             self.rowsecurity == other.rowsecurity,
             self.persistence == other.persistence,
+            self.rel_options == other.rel_options,
         )
         return all(equalities)

--- a/results/schemainspect/pg/obj.py
+++ b/results/schemainspect/pg/obj.py
@@ -113,8 +113,13 @@ class InspectedSelectable(BaseInspectedSelectable):
                     self.persistence_modifier, n, self.parent_table, self.partition_def
                 )
         elif self.relationtype == "v":
-            create_statement = "create or replace view {} as {}\n".format(
-                n, self.definition
+            view_options = ""
+
+            if self.rel_options is not None and len(self.rel_options) > 0:
+                view_options = f"with ({','.join(self.rel_options)})"
+
+            create_statement = "create or replace view {} {} as {}\n".format(
+                n, view_options, self.definition
             )
         elif self.relationtype == "m":
             create_statement = "create materialized view {} as {}\n".format(
@@ -275,6 +280,7 @@ class InspectedFunction(InspectedSelectable):
             definition=definition,
             relationtype="f",
             comment=comment,
+            rel_options=None
         )
 
     @property
@@ -1474,6 +1480,7 @@ class PostgreSQL:
             s = InspectedSelectable(
                 oid=f.oid,
                 name=f.name,
+                rel_options=f.reloptions,
                 schema=f.schema,
                 columns=od((c.name, c) for c in columns),
                 relationtype=f.relationtype,

--- a/results/schemainspect/pg/sql/relations.sql
+++ b/results/schemainspect/pg/sql/relations.sql
@@ -22,6 +22,7 @@ r as (
         c.relname as name,
         n.nspname as schema,
         c.relkind as relationtype,
+        c.reloptions as reloptions,
         c.oid as oid,
         case when c.relkind in ('m', 'v') then
           pg_get_viewdef(c.oid)
@@ -70,6 +71,7 @@ select
     r.relationtype,
     r.schema,
     r.name,
+    r.reloptions,
     r.definition as definition,
     a.attnum as position_number,
     a.attname as attname,


### PR DESCRIPTION
This pull requests adds support for preserving relation options for views, which is important to preserve things like row-level security in views (via the `security_invoker=true` relation option).